### PR TITLE
chore: restrict GitHub token permissions

### DIFF
--- a/.github/workflows/deploy-test-no-push.yaml
+++ b/.github/workflows/deploy-test-no-push.yaml
@@ -5,6 +5,8 @@
 # To use this workflow, you need to create a branch called docker-test, and push to that branch.
 
 name: Deploy (No Push)
+permissions:
+  contents: read
 
 # Deploy will run on each GitHub release.
 # yamllint disable-line rule:truthy
@@ -64,6 +66,9 @@ jobs:
     name: 👷 Build & Deploy ${{ matrix.architecture }}
     needs: information
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         architecture: ${{ fromJson(needs.information.outputs.architectures) }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,8 @@
 # yamllint disable rule:line-length
 
 name: Deploy
+permissions:
+  contents: read
 
 # Deploy will run on each GitHub release.
 # yamllint disable-line rule:truthy
@@ -66,6 +68,9 @@ jobs:
     name: 👷 Build & Deploy ${{ matrix.architecture }}
     needs: information
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         architecture: ${{ fromJson(needs.information.outputs.architectures) }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 ---
 name: Lint
 
+permissions:
+  contents: read
+
 # yamllint disable-line rule:truthy
 on: [push, pull_request]
 

--- a/.github/workflows/standalone-docker-build-test.yml
+++ b/.github/workflows/standalone-docker-build-test.yml
@@ -2,6 +2,9 @@
 # yamllint disable rule:comments-indentation
 name: Publish Standalone Docker image
 
+permissions:
+  contents: read
+
 # Triggers on our test branch for building docker.
 on:
   push:

--- a/.github/workflows/standalone-docker-publish.yml
+++ b/.github/workflows/standalone-docker-publish.yml
@@ -2,6 +2,9 @@
 # yamllint disable rule:comments-indentation
 name: Publish Standalone Docker image
 
+permissions:
+  contents: read
+
 # Only make and deploy new docker images on tagged releases.
 on:
   release:


### PR DESCRIPTION
## Summary
- scope default GITHUB_TOKEN to read-only for contents
- grant packages scope only to jobs that interact with GHCR

## Testing
- `pre-commit run --files .github/workflows/deploy-test-no-push.yaml .github/workflows/deploy.yaml .github/workflows/lint.yaml .github/workflows/standalone-docker-build-test.yml .github/workflows/standalone-docker-publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_689651a4ebf48333a9c68256be8b78e8